### PR TITLE
Changed rest_client gem to rest-client gem

### DIFF
--- a/lib/bitflyer/net.rb
+++ b/lib/bitflyer/net.rb
@@ -1,4 +1,4 @@
-require "rest_client"
+require "rest-client"
 require "net/http"
 require "openssl"
 


### PR DESCRIPTION
rest_client gem was deprecated and this gem is not available now.
I changed rest_client gem to rest-client gem.
Would you mind to confirm this change and merge this change into your repository.